### PR TITLE
Fix: change num_images from list to INT to avoid type error

### DIFF
--- a/gpt_image_nodes.py
+++ b/gpt_image_nodes.py
@@ -221,7 +221,7 @@ class GrsaiGPTImageVIP_Node:
                     ],
                     {"default": "gpt-image-2-vip"},
                 ),
-                "num_images": ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], {"default": 1}),
+                "num_images": ("INT", {"default": 1, "min": 1, "max": 12, "step": 1}),
             },
             "optional": {
                 "aspect_ratio": (
@@ -413,7 +413,7 @@ class GrsaiGPTImage_Node:
                     ],
                     {"default": "gpt-image-2"},
                 ),
-                "num_images": ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], {"default": 1}),
+                "num_images": ("INT", {"default": 1, "min": 1, "max": 12, "step": 1}),
             },
             "optional": {
                 "aspect_ratio": (

--- a/nano_banana_2_nodes.py
+++ b/nano_banana_2_nodes.py
@@ -129,7 +129,7 @@ class GrsaiNanoBanana2_Node:
                     ],
                     {"default": "nano-banana-2"},
                 ),
-                "num_images": ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], {"default": 1}),
+                "num_images": ("INT", {"default": 1, "min": 1, "max": 12, "step": 1}),
             },
             "optional": {
                 "aspect_ratio": (

--- a/nano_banana_nodes.py
+++ b/nano_banana_nodes.py
@@ -129,7 +129,7 @@ class GrsaiNanoBanana_Node:
                     ],
                     {"default": "nano-banana-fast"},
                 ),
-                "num_images": ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], {"default": 1}),
+                "num_images": ("INT", {"default": 1, "min": 1, "max": 12, "step": 1}),
             },
             "optional": {
                 "aspect_ratio": (

--- a/nano_banana_pro_nodes.py
+++ b/nano_banana_pro_nodes.py
@@ -132,7 +132,7 @@ class GrsaiNanoBananaPro_Node:
                     ],
                     {"default": "nano-banana-pro"},
                 ),
-                "num_images": ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], {"default": 1}),
+                "num_images": ("INT", {"default": 1, "min": 1, "max": 12, "step": 1}),
             },
             "optional": {
                 "aspect_ratio": (


### PR DESCRIPTION
### 錯誤摘要
修復了 `GPT Image`以及 `Nano Banana` 系列節點中，因 `num_images` 欄位型態不匹配導致的 `Value not in list` 報錯。

### 問題原因
原本這些節點的 `num_images` 被定義為整數陣列 `[1, 2, 3, ...]`。前端網頁傳回的值會變成字串（如 `'2'`），與後端預期的整數不符，進而觸發 ComfyUI 的報錯並導致無法執行。

### 解決方案
將幾個節點的 `num_images` 欄位統一修改為 `"INT"` 類型（範圍限制 `1` 到 `12`）：